### PR TITLE
Hotfix/exit code  

### DIFF
--- a/srcs/built_in/exit.c
+++ b/srcs/built_in/exit.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:20:38 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/03/26 12:39:14 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/06/03 19:19:05 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,7 +90,7 @@ int	ft_exit(char **cmds, t_minishell *minishell)
 	if (minishell->pid != 0)
 		ft_dprintf(STDOUT_FILENO, "%s\n", EXIT);
 	if (cmds[1] == NULL)
-		ret = 0;
+		ret = minishell->exit_status;
 	else if (check_arg_exit(cmds[1]) == 0)
 	{
 		ft_dprintf(STDOUT_FILENO, EXIT_ERROR, cmds[1]);


### PR DESCRIPTION
This pull request updates the behavior of the `ft_exit` function in the `srcs/built_in/exit.c` file to use the `exit_status` from the `minishell` structure when no arguments are provided, instead of defaulting to `0`. Additionally, it includes an update to the file's metadata.

Functional changes:

* [`srcs/built_in/exit.c`]: Modified the `ft_exit` function to set the return value to `minishell->exit_status` when no arguments are provided, ensuring the exit status reflects the shell's state.