### PR TITLE
build: added -g3 to compilation flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DEPS		:= $(OBJS:.o=.d)
 # ********** FLAGS AND COMPILATION FLAGS ************************************* #
 
 CC			:= cc
-CFLAGS		:= -Wall -Wextra -Werror
+CFLAGS		:= -Wall -Wextra -Werror -g3
 CPPFLAGS	:= -MMD -MP -I incs/ -I libft/incs/
 RLFLAGS		:= -lreadline
 

--- a/srcs/exec/cmd_path.c
+++ b/srcs/exec/cmd_path.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:21:36 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/03/26 13:15:35 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/06/17 20:18:45 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,6 +78,7 @@ static char	*find_full_path(t_minishell *minishell, t_path_cmds *path_cmds,
 {
 	char	*full_path;
 
+	full_path = NULL;
 	path_cmds->paths = ft_split(path_cmds->path_env, ':');
 	if (path_cmds->paths == NULL)
 	{


### PR DESCRIPTION
This pull request introduces debugging enhancements and a minor fix for uninitialized variables. The most significant changes include adding debugging flags to the compilation process and initializing a variable to prevent potential undefined behavior.

### Compilation and Debugging Enhancements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L13-R13): Added the `-g3` flag to `CFLAGS` to enable maximum debugging information during compilation.

### Bug Fixes:
* [`srcs/exec/cmd_path.c`](diffhunk://#diff-5ee58517bb8641dc7ca7410621ed94f38264bc56fa5ea818f71a1e198e22b0e1R81): Initialized the `full_path` variable to `NULL` in the `find_full_path` function to prevent potential undefined behavior.