### PR TITLE
fix: removed non IFS characters from splitting on charset + made it a…

### DIFF
--- a/incs/utils.h
+++ b/incs/utils.h
@@ -6,12 +6,14 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:18:57 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/03/26 11:34:25 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/06/22 19:03:11 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef UTILS_H
 # define UTILS_H
+
+# define IFS_CHARACTERS " \t\n"
 
 typedef struct s_minishell	t_minishell;
 typedef struct s_token		t_token;

--- a/srcs/exec/remake_cmds.c
+++ b/srcs/exec/remake_cmds.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   remake_cmds.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lbuisson <lbuisson@student.42lyon.fr>      +#+  +:+       +#+        */
+/*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:22:13 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/05/20 14:13:33 by lbuisson         ###   ########lyon.fr   */
+/*   Updated: 2025/06/22 19:03:19 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,11 +47,11 @@ char	**remake_cmds(char **cmds, int *index)
 	int		new_cmd_len;
 	char	**ret;
 
-	cmds_len = 0;
-	new_cmd_len = 0;
-	new_cmd = ft_split_charset(cmds[*index], " \t\n\v\f\r");
+	new_cmd = ft_split_charset(cmds[*index], IFS_CHARACTERS);
 	if (new_cmd == NULL)
 		return (NULL);
+	cmds_len = 0;
+	new_cmd_len = 0;
 	while (cmds[cmds_len])
 		cmds_len++;
 	while (new_cmd[new_cmd_len])


### PR DESCRIPTION
This pull request introduces a minor improvement to the code by centralizing the definition of characters used for splitting strings into a single macro, `IFS_CHARACTERS`, and replacing hardcoded values with this macro.

### Code improvement:

* [`incs/utils.h`](diffhunk://#diff-12ad4785e2b2faa05770ff523b038a2ff229a1b81f9dbcd349cb975e66c7a1beL9-R17): Added a new macro `IFS_CHARACTERS` to define the set of characters used for splitting strings (`" \t\n"`).
* [`srcs/exec/remake_cmds.c`](diffhunk://#diff-cc9eba92aeb701935545bb70399489a416fa68125f7381541ffa0ca866c95ef3L50-R54): Replaced the hardcoded string `" \t\n\v\f\r"` with the newly defined `IFS_CHARACTERS` macro in the `remake_cmds` function, improving maintainability and consistency.

### File metadata updates:

* Updated file headers in `incs/utils.h` and `srcs/exec/remake_cmds.c` to reflect changes in authorship and timestamps. [[1]](diffhunk://#diff-12ad4785e2b2faa05770ff523b038a2ff229a1b81f9dbcd349cb975e66c7a1beL9-R17) [[2]](diffhunk://#diff-cc9eba92aeb701935545bb70399489a416fa68125f7381541ffa0ca866c95ef3L6-R9)