### PR TITLE
Hotfix/ambiguous redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,81 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# misc
+*.out
+
+.build/
+.obj/
+.bonus
+
+libft.a
+minishell
+
+tmp.c
+test*
+test_g/
+test_l/
+man/
+test/
+test.c
+test2.c
+test.mk
+
+.valgrind_suppress.txt
+
+*callgrind*
+*output*
+
+minishell_test_dir/
+test_results.log
+.vscode

--- a/incs/utils.h
+++ b/incs/utils.h
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:18:57 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/07/24 14:17:59 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:52:06 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ void	cleanup_shell(t_minishell *minishell);
 void	free_token_list(t_token *tokens);
 
 char	**ft_free_double(char **strs);
-char	**create_new_cmds_array(char **old_cmds, int old_index, 
+char	**create_new_cmds_array(char **old_cmds, int old_index, \
 								char **file_names, int file_count);
 
 bool	add_token_in_place(t_token **tokens, char *content, t_node_type type);

--- a/incs/utils.h
+++ b/incs/utils.h
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:18:57 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/07/24 13:08:35 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 14:17:59 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,12 +20,22 @@ typedef struct s_minishell	t_minishell;
 typedef struct s_token		t_token;
 typedef enum e_node_type	t_node_type;
 
+typedef struct s_new_array
+{
+	char	**new_cmds;
+	int		old_len;
+	int		new_len;
+	int		dest_index;
+}	t_new_array;
+
 void	cleanup_exit(t_minishell *minishell);
 void	cleanup_loop(t_minishell *minishell);
 void	cleanup_shell(t_minishell *minishell);
 void	free_token_list(t_token *tokens);
 
 char	**ft_free_double(char **strs);
+char	**create_new_cmds_array(char **old_cmds, int old_index, 
+								char **file_names, int file_count);
 
 bool	add_token_in_place(t_token **tokens, char *content, t_node_type type);
 bool	add_token(t_token **tokens, char *content, t_node_type type);

--- a/incs/utils.h
+++ b/incs/utils.h
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:18:57 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/06/22 19:03:11 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 13:08:35 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define UTILS_H
 
 # define IFS_CHARACTERS " \t\n"
+# define EXIT_NL		"exit\n"
 
 typedef struct s_minishell	t_minishell;
 typedef struct s_token		t_token;

--- a/incs/wildcard.h
+++ b/incs/wildcard.h
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:19:13 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/03/26 11:34:54 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:34:04 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@
 
 typedef struct s_minishell	t_minishell;
 typedef struct s_token		t_token;
+typedef struct s_ast		t_ast;
+typedef struct s_exp_qu		t_exp_qu;
 
 # define CURRENT_DIR	"."
 
@@ -30,16 +32,28 @@ typedef struct s_wildcard
 	int				count;
 }	t_wildcard;
 
-void	expand_wildcards(t_minishell *minishell);
-
 bool	add_filename(char **filenames, char *name, int index);
 bool	contain_wildcard(char *token);
+bool	is_ambiguous_redirect(char *original_pattern);
 bool	should_include_file(char *pattern, char *filename);
 bool	wildcard_match(const char *pattern, const char *str);
+bool	handle_wildcard_expansion(t_ast *node, t_exp_qu *exp_qu);
 
 char	**allocate_2d_array(int count);
 char	**get_file_names(char *pattern, int count);
+char	**expand_wildcard_in_cmds(char **cmds, int index);
+
+char	*expand_wildcard_pattern(char *pattern);
 
 int		count_matches(char *pattern);
+int		count_wildcard_matches(char *pattern);
+int		qu_check(t_ast *node, t_exp_qu *exp_qu);
+int		check_redirect_ambiguity(t_ast *node, t_exp_qu *exp_qu, \
+					char *original_pattern);
+int	init_expansion_data(t_ast *node, t_exp_qu *exp_qu, \
+				t_minishell *minishell, char **original_pattern);
+
+void	expand_condition(t_ast *node, t_exp_qu *exp_qu);
+
 
 #endif

--- a/incs/wildcard.h
+++ b/incs/wildcard.h
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:19:13 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/07/24 15:34:04 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:49:27 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,8 +42,6 @@ bool	handle_wildcard_expansion(t_ast *node, t_exp_qu *exp_qu);
 char	**allocate_2d_array(int count);
 char	**get_file_names(char *pattern, int count);
 char	**expand_wildcard_in_cmds(char **cmds, int index);
-
-char	*expand_wildcard_pattern(char *pattern);
 
 int		count_matches(char *pattern);
 int		count_wildcard_matches(char *pattern);

--- a/incs/wildcard.h
+++ b/incs/wildcard.h
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:19:13 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/07/24 15:49:27 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:51:52 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,10 +48,9 @@ int		count_wildcard_matches(char *pattern);
 int		qu_check(t_ast *node, t_exp_qu *exp_qu);
 int		check_redirect_ambiguity(t_ast *node, t_exp_qu *exp_qu, \
 					char *original_pattern);
-int	init_expansion_data(t_ast *node, t_exp_qu *exp_qu, \
+int		init_expansion_data(t_ast *node, t_exp_qu *exp_qu, \
 				t_minishell *minishell, char **original_pattern);
 
 void	expand_condition(t_ast *node, t_exp_qu *exp_qu);
-
 
 #endif

--- a/minishell.mk
+++ b/minishell.mk
@@ -61,22 +61,23 @@ SRC	+= $(addprefix $(EXECDIR), $(addsuffix .c, $(EXECSRC)))
 
 override EXECSRC		:= \
 	and_exec \
-	exec \
 	cmd_check \
-	cmd_path \
-	cmd_path_utils \
 	cmd_exec \
+	cmd_path_utils \
+	cmd_path \
+	exec_utils \
+	exec \
+	expand_quotes_exec \
+	expand_routine \
+	handle_fd \
+	heredoc_exec \
 	or_exec \
 	pipe_exec \
+	quotes_utils \
 	redirappend_exec \
 	redirin_exec \
 	redirout_exec \
-	heredoc_exec \
-	exec_utils \
-	handle_fd \
-	expand_quotes_exec \
-	quotes_utils \
-	remake_cmds \
+	remake_cmds
 
 SRC	+= $(addprefix $(EXPANDDIR), $(addsuffix .c, $(EXPANDSRC)))
 
@@ -88,7 +89,7 @@ override EXPANDSRC		:= \
 	expand_main_loop \
 	expand_quote_handling \
 	expand_utils \
-	expand \
+	expand
 
 SRC += $(addprefix $(HEREDOCDIR), $(addsuffix .c, $(HEREDOCSRC)))
 
@@ -146,7 +147,8 @@ override UTILSSRC		:= \
 SRC += $(addprefix $(WILDCARDIR), $(addsuffix .c, $(WILDCARDSRC)))
 
 override WILDCARDSRC	:= \
+	create_array \
 	file_utils \
 	patterns \
-	wildcard_utils \
 	wildcard \
+	wildcard_utils

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:21:42 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/07/24 13:53:59 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:48:01 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@
 int	exec_minishell(t_ast *node, t_minishell *minishell)
 {
 	int						ret;
-	const static t_handler	exec[] = {&handle_cmd, &handle_pipe, &handle_or,
+	static const t_handler	exec[] = {&handle_cmd, &handle_pipe, &handle_or,
 		&handle_and, &handle_redirin, &handle_redirout, &handle_heredocin,
 		&handle_redirappend, 0, 0, &handle_builtin};
 

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:21:42 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/03/26 13:19:30 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 13:53:59 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,8 @@
 
 int	exec_minishell(t_ast *node, t_minishell *minishell)
 {
-	int					ret;
-	static t_handler	exec[] = {&handle_cmd, &handle_pipe, &handle_or,
+	int						ret;
+	const static t_handler	exec[] = {&handle_cmd, &handle_pipe, &handle_or,
 		&handle_and, &handle_redirin, &handle_redirout, &handle_heredocin,
 		&handle_redirappend, 0, 0, &handle_builtin};
 

--- a/srcs/exec/expand_quotes_exec.c
+++ b/srcs/exec/expand_quotes_exec.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:21:44 by lbuisson          #+#    #+#             */
-/*   Updated: 2025/07/24 15:32:08 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:50:37 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -109,7 +109,6 @@ int	init_expansion_data(t_ast *node, t_exp_qu *exp_qu, \
 	*original_pattern = ft_strdup(node->cmd->cmds[exp_qu->i]);
 	if (!*original_pattern)
 		return (1);
-	(void) minishell;
 	exp_qu->expanded = expand_env_vars(node->cmd->cmds[exp_qu->i],
 			minishell, &exp_qu->exp, &exp_qu->quote);
 	if (exp_qu->expanded == NULL)

--- a/srcs/exec/expand_routine.c
+++ b/srcs/exec/expand_routine.c
@@ -1,0 +1,85 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_routine.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/24 15:31:05 by gueberso          #+#    #+#             */
+/*   Updated: 2025/07/24 15:38:54 by gueberso         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ast.h"
+#include "exec.h"
+#include "libft.h"
+#include "utils.h"
+#include "wildcard.h"
+
+static int	expand_quotes_init(t_ast *node, t_exp_qu *exp_qu, \
+	t_minishell *minishell)
+{
+	char	*original_pattern;
+
+	if (init_expansion_data(node, exp_qu, minishell, &original_pattern) == 1)
+		return (1);
+	if (check_redirect_ambiguity(node, exp_qu, original_pattern) == 1)
+	{
+		free(original_pattern);
+		return (1);
+	}
+	free(original_pattern);
+	exp_qu->temp = node->cmd->cmds[exp_qu->i];
+	expand_condition(node, exp_qu);
+	return (0);
+}
+
+static int	handle_word_splitting(t_ast *node, t_exp_qu *data)
+{
+	data->tmp_cmds = node->cmd->cmds;
+	node->cmd->cmds = remake_cmds(node->cmd->cmds, &data->i);
+	if (node->cmd->cmds == NULL)
+	{
+		ft_free_double(data->tmp_cmds);
+		return (1);
+	}
+	free(data->expanded);
+	data->i++;
+	return (0);
+}
+
+static int	handle_quote_processing(t_ast *node, t_exp_qu *data)
+{
+	if (qu_check(node, data) == 1)
+		return (1);
+	if (handle_wildcard_expansion(node, data) == false)
+		return (1);
+	return (0);
+}
+
+int	expand_quotes_exec(t_ast *node, t_minishell *minishell)
+{
+	t_exp_qu	data;
+
+	ft_memset(&data, 0, sizeof(t_exp_qu));
+	while (node->cmd->cmds[data.i])
+	{
+		if (expand_quotes_init(node, &data, minishell) == 1)
+			return (1);
+		if (data.export == 0 && data.exp == 1 && data.quote == 0
+			&& node->cmd->cmds[data.i])
+		{
+			if (handle_word_splitting(node, &data) == 1)
+				return (1);
+		}
+		else if (data.export == 1 || data.exp == 0 || \
+			(data.exp == 1 && data.quote == 1))
+		{
+			if (data.exp == 1 && data.quote == 1)
+				data.i++;
+			if (handle_quote_processing(node, &data) == 1)
+				return (1);
+		}
+	}
+	return (0);
+}

--- a/srcs/minishell_process/loop.c
+++ b/srcs/minishell_process/loop.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 09:22:02 by gueberso          #+#    #+#             */
-/*   Updated: 2025/03/26 13:50:38 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:39:28 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,6 @@
 #include "options.h"
 #include "signals.h"
 #include "utils.h"
-#include "wildcard.h"
 
 static void	build_and_execute(t_minishell *minishell)
 {
@@ -35,7 +34,6 @@ static void	process_command(t_minishell *minishell)
 	tokenize_input(minishell);
 	split_operators(minishell);
 	check_heredoc(minishell);
-	expand_wildcards(minishell);
 	syntax_check(minishell);
 	print_tokens(minishell);
 	build_and_execute(minishell);
@@ -51,7 +49,7 @@ static int	process_input(t_minishell *minishell)
 	}
 	if (minishell->input == NULL)
 	{
-		ft_dprintf(STDERR_FILENO, "exit\n");
+		ft_dprintf(STDERR_FILENO, EXIT_NL);
 		return (-1);
 	}
 	init_global();

--- a/srcs/wildcard/create_array.c
+++ b/srcs/wildcard/create_array.c
@@ -1,0 +1,64 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   create_array.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/24 14:06:15 by gueberso          #+#    #+#             */
+/*   Updated: 2025/07/24 14:47:37 by gueberso         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include "utils.h"
+
+static int	copy_strings_segment(t_new_array *n_array, char **src, \
+			int src_start, int count)
+{
+	int	i;
+
+	i = 0;
+	while (i < count)
+	{
+		n_array->new_cmds[n_array->dest_index] = ft_strdup(src[src_start + i]);
+		if (!n_array->new_cmds[n_array->dest_index])
+			return (0);
+		i++;
+		n_array->dest_index++;
+	}
+	return (1);
+}
+
+static int	get_old_len(char **old_cmds)
+{
+	int	old_len;
+
+	old_len = 0;
+	while (old_cmds[old_len])
+		old_len++;
+	return (old_len);
+}
+
+char	**create_new_cmds_array(char **old_cmds, int old_index, \
+	char **file_names, int file_count)
+{
+	t_new_array	n_array;
+
+	n_array.old_len = get_old_len(old_cmds);
+	n_array.new_len = n_array.old_len - 1 + file_count;
+	n_array.new_cmds = malloc(sizeof(char *) * (n_array.new_len + 1));
+	if (!n_array.new_cmds)
+		return (NULL);
+	n_array.dest_index = 0;
+	if (!copy_strings_segment(&n_array, old_cmds, 0, old_index)
+		|| !copy_strings_segment(&n_array, file_names, 0, file_count)
+		|| !copy_strings_segment(&n_array, old_cmds, old_index + 1, \
+			n_array.old_len - old_index - 1))
+	{
+		ft_free_double(n_array.new_cmds);
+		return (NULL);
+	}
+	n_array.new_cmds[n_array.new_len] = NULL;
+	return (n_array.new_cmds);
+}

--- a/srcs/wildcard/wildcard.c
+++ b/srcs/wildcard/wildcard.c
@@ -6,20 +6,13 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 12:00:00 by gueberso          #+#    #+#             */
-/*   Updated: 2025/07/24 14:06:12 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:49:25 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 #include "utils.h"
 #include "wildcard.h"
-
-char	*expand_wildcard_pattern(char *pattern)
-{
-	if (!pattern || !contain_wildcard(pattern))
-		return (ft_strdup(pattern));
-	return (ft_strdup(pattern));
-}
 
 int	count_wildcard_matches(char *pattern)
 {


### PR DESCRIPTION
This pull request introduces significant updates to the wildcard expansion functionality and refactors related code. The changes include the addition of new utility functions and restructuring of wildcard handling. The most important changes are grouped into themes and summarized below.

### Wildcard Expansion Enhancements:
* Added new utility functions, such as `create_new_cmds_array`, `expand_wildcard_in_cmds`, and `count_wildcard_matches`, to improve the modularity and clarity of wildcard handling (`incs/utils.h`, `srcs/wildcard/create_array.c`, `srcs/wildcard/wildcard.c`).

### Refactoring and Code Organization:
* Moved the `expand_quotes_exec` function logic into a new `expand_routine.c` file, separating concerns and improving readability.

### Structural and Type Updates:
* Changed `static` to `const static` for the `exec` handler array in `exec.c` to ensure immutability (`srcs/exec/exec.c`).

### Bug Fixes and Minor Updates:
* Fixed potential ambiguity in redirection patterns by introducing the `check_redirect_ambiguity` function.
* Replaced hardcoded "exit\n" with a defined constant `EXIT_NL` for consistency.

These changes collectively improve the maintainability, functionality, and clarity of the `minishell` codebase, particularly in handling wildcard expansions.