### PR TITLE
Hotfix/exec and fds

### DIFF
--- a/srcs/exec/cmd_exec.c
+++ b/srcs/exec/cmd_exec.c
@@ -73,6 +73,8 @@ static int	exec_cmd(t_ast *node, t_minishell *minishell)
 		node->cmd->path = ft_strdup(node->cmd->cmds[0]);
 		if (node->cmd->path == NULL)
 			exit(error_handling_exec(minishell, NULL));
+		if (execve(node->cmd->path, node->cmd->cmds, env) == -1)
+			node->cmd->path = find_exec_cmd(node->cmd->cmds, minishell, env);
 	}
 	else
 		node->cmd->path = find_exec_cmd(node->cmd->cmds, minishell, env);

--- a/srcs/utils/cleanup_minishell.c
+++ b/srcs/utils/cleanup_minishell.c
@@ -31,7 +31,8 @@ static void	close_free_and_reinit_fds(t_fd_info *fd)
 	if (fd->fds)
 		free(fd->fds);
 	fd->fds = malloc(sizeof(int) * 10);
-	if (!fd->fds) {
+	if (!fd->fds)
+	{
 		fd->nb_elems = 0;
 		fd->capacity = 0;
 		return ;

--- a/srcs/utils/cleanup_minishell.c
+++ b/srcs/utils/cleanup_minishell.c
@@ -28,8 +28,14 @@ static void	close_free_and_reinit_fds(t_fd_info *fd)
 		close(fd->fds[i]);
 		i++;
 	}
-	free(fd->fds);
+	if (fd->fds)
+		free(fd->fds);
 	fd->fds = malloc(sizeof(int) * 10);
+	if (!fd->fds) {
+		fd->nb_elems = 0;
+		fd->capacity = 0;
+		return ;
+	}
 	fd->nb_elems = 0;
 	fd->capacity = 10;
 }

--- a/srcs/utils/free_utils.c
+++ b/srcs/utils/free_utils.c
@@ -26,6 +26,7 @@ void	close_and_free_fds(t_fd_info *fd)
 		i++;
 	}
 	free(fd->fds);
+	fd->fds = NULL;	
 }
 
 void	free_token_list(t_token *tokens)


### PR DESCRIPTION
**File descriptor management improvements:**

* In `close_free_and_reinit_fds`, added checks to ensure `fd->fds` is only freed if it is not `NULL`, and improved error handling after memory allocation by resetting `nb_elems` and `capacity` if allocation fails.
* In `close_and_free_fds`, explicitly sets `fd->fds` to `NULL` after freeing to prevent potential use-after-free bugs.

**Command execution logic:**

* In `exec_cmd`, added logic to attempt to find and execute the command using `find_exec_cmd` if the initial `execve` call fails, which was what the right behavior few commits back behind.